### PR TITLE
DM-41481: Deploy w_41 and use custom STS Butler config.

### DIFF
--- a/kubernetes/overlays/bts/kustomization.yaml
+++ b/kubernetes/overlays/bts/kustomization.yaml
@@ -2,7 +2,7 @@ images:
 - name: ghcr.io/lsst-dm/embargo-butler-enqueue
   newTag: "0.99"
 - name: ghcr.io/lsst-dm/embargo-butler-ingest
-  newTag: "0.99"
+  newTag: "0.99.2-w_2023_41"
 - name: ghcr.io/lsst-dm/embargo-butler-idle
   newTag: "0.99"
 - name: docker.io/redis

--- a/kubernetes/overlays/sts/ingest-deploy.yaml
+++ b/kubernetes/overlays/sts/ingest-deploy.yaml
@@ -48,7 +48,7 @@ spec:
         - name: BUCKET
           value: rubin-sts
         - name: BUTLER_REPO
-          value: s3://rubin-sts/butler.yaml
+          value: s3://rubin-sts/butler-ingest.yaml
         - name: REDIS_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/kubernetes/overlays/sts/kustomization.yaml
+++ b/kubernetes/overlays/sts/kustomization.yaml
@@ -2,7 +2,7 @@ images:
 - name: ghcr.io/lsst-dm/embargo-butler-enqueue
   newTag: "0.99"
 - name: ghcr.io/lsst-dm/embargo-butler-ingest
-  newTag: "0.99"
+  newTag: "0.99.2-w_2023_41"
 - name: ghcr.io/lsst-dm/embargo-butler-idle
   newTag: "0.99"
 - name: docker.io/redis

--- a/kubernetes/overlays/summit/kustomization.yaml
+++ b/kubernetes/overlays/summit/kustomization.yaml
@@ -2,7 +2,7 @@ images:
 - name: ghcr.io/lsst-dm/embargo-butler-enqueue
   newTag: "0.99"
 - name: ghcr.io/lsst-dm/embargo-butler-ingest
-  newTag: "0.99.1"
+  newTag: "0.99.2-w_2023_41"
 - name: ghcr.io/lsst-dm/embargo-butler-idle
   newTag: "0.99"
 - name: docker.io/redis

--- a/kubernetes/overlays/tts/kustomization.yaml
+++ b/kubernetes/overlays/tts/kustomization.yaml
@@ -2,7 +2,7 @@ images:
 - name: ghcr.io/lsst-dm/embargo-butler-enqueue
   newTag: "0.99"
 - name: ghcr.io/lsst-dm/embargo-butler-ingest
-  newTag: "0.99"
+  newTag: "0.99.2-w_2023_41"
 - name: ghcr.io/lsst-dm/embargo-butler-idle
   newTag: "0.99"
 - name: docker.io/redis


### PR DESCRIPTION
The custom config is needed to avoid having to mount S3DF filesystems into the container, since STS (/repo/ir2) doesn't use a bucket for user files.