### PR TITLE
rubin-embargo metrics

### DIFF
--- a/kubernetes/overlays/bts/embargo-metrics-deploy.yaml
+++ b/kubernetes/overlays/bts/embargo-metrics-deploy.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics
-        image: "ghcr.io/lsst-dm/embargo-butler-ingest:prod"
+        image: "image: ghcr.io/slaclab/rubin-embargo-metrics:latest"
         env:
         - name: REDIS_PASSWORD
           valueFrom:

--- a/kubernetes/overlays/bts/embargo-metrics-deploy.yaml
+++ b/kubernetes/overlays/bts/embargo-metrics-deploy.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics
-        image: "image: ghcr.io/slaclab/rubin-embargo-metrics:latest"
+        image: "ghcr.io/slaclab/rubin-embargo-metrics:latest"
         env:
         - name: REDIS_PASSWORD
           valueFrom:

--- a/kubernetes/overlays/bts/embargo-metrics-deploy.yaml
+++ b/kubernetes/overlays/bts/embargo-metrics-deploy.yaml
@@ -27,6 +27,8 @@ spec:
             secretKeyRef:
               name: redis
               key: redis-password
+        - name: REDIS_URL
+          value: redis://redis:6379
         resources:
           limits:
             cpu: "1"

--- a/kubernetes/overlays/bts/embargo-metrics-deploy.yaml
+++ b/kubernetes/overlays/bts/embargo-metrics-deploy.yaml
@@ -2,21 +2,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: sts-embargo-metrics
+  name: bts-embargo-metrics
   labels:
     app: metrics
-    site: sts
+    site: bts
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: metrics
-      site: sts
+      site: bts
   template:
     metadata:
       labels:
         app: metrics
-        site: sts
+        site: bts
     spec:
       containers:
       - name: metrics

--- a/kubernetes/overlays/bts/kustomization.yaml
+++ b/kubernetes/overlays/bts/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
 - idle-deploy.yaml
 - ingest-deploy.yaml
 - redis-deploy.yaml
+- embargo-metrics-deploy.yaml
 
 secretGenerator:
 - name: s3

--- a/kubernetes/overlays/sts/embargo-metrics-deploy.yaml
+++ b/kubernetes/overlays/sts/embargo-metrics-deploy.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics
-        image: "ghcr.io/lsst-dm/embargo-butler-ingest:prod"
+        image: "image: ghcr.io/slaclab/rubin-embargo-metrics:latest"
         env:
         - name: REDIS_PASSWORD
           valueFrom:

--- a/kubernetes/overlays/sts/embargo-metrics-deploy.yaml
+++ b/kubernetes/overlays/sts/embargo-metrics-deploy.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics
-        image: "image: ghcr.io/slaclab/rubin-embargo-metrics:latest"
+        image: "ghcr.io/slaclab/rubin-embargo-metrics:latest"
         env:
         - name: REDIS_PASSWORD
           valueFrom:

--- a/kubernetes/overlays/sts/embargo-metrics-deploy.yaml
+++ b/kubernetes/overlays/sts/embargo-metrics-deploy.yaml
@@ -27,6 +27,8 @@ spec:
             secretKeyRef:
               name: redis
               key: redis-password
+        - name: REDIS_URL
+          value: redis://redis:6379
         resources:
           limits:
             cpu: "1"

--- a/kubernetes/overlays/sts/embargo-metrics-deploy.yaml
+++ b/kubernetes/overlays/sts/embargo-metrics-deploy.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: embargo-metrics
+  labels:
+    app: metrics
+    site: sts
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: metrics
+      site: sts
+  template:
+    metadata:
+      labels:
+        app: metrics
+        site: sts
+    spec:
+      containers:
+      - name: metrics
+        image: "ghcr.io/lsst-dm/embargo-butler-ingest:prod"
+        env:
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: redis
+              key: redis-password
+        resources:
+          limits:
+            cpu: "1"
+            memory: "2Gi"

--- a/kubernetes/overlays/sts/kustomization.yaml
+++ b/kubernetes/overlays/sts/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
 - idle-deploy.yaml
 - ingest-deploy.yaml
 - redis-deploy.yaml
+- embargo-metrics-deploy.yaml
 
 secretGenerator:
 - name: s3

--- a/kubernetes/overlays/summit/embargo-metrics-deploy.yaml
+++ b/kubernetes/overlays/summit/embargo-metrics-deploy.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics
-        image: "ghcr.io/lsst-dm/embargo-butler-ingest:prod"
+        image: "image: ghcr.io/slaclab/rubin-embargo-metrics:latest"
         env:
         - name: REDIS_PASSWORD
           valueFrom:

--- a/kubernetes/overlays/summit/embargo-metrics-deploy.yaml
+++ b/kubernetes/overlays/summit/embargo-metrics-deploy.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics
-        image: "image: ghcr.io/slaclab/rubin-embargo-metrics:latest"
+        image: "ghcr.io/slaclab/rubin-embargo-metrics:latest"
         env:
         - name: REDIS_PASSWORD
           valueFrom:

--- a/kubernetes/overlays/summit/embargo-metrics-deploy.yaml
+++ b/kubernetes/overlays/summit/embargo-metrics-deploy.yaml
@@ -2,21 +2,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: sts-embargo-metrics
+  name: summit-embargo-metrics
   labels:
     app: metrics
-    site: sts
+    site: summit
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: metrics
-      site: sts
+      site: summit
   template:
     metadata:
       labels:
         app: metrics
-        site: sts
+        site: summit
     spec:
       containers:
       - name: metrics

--- a/kubernetes/overlays/summit/embargo-metrics-deploy.yaml
+++ b/kubernetes/overlays/summit/embargo-metrics-deploy.yaml
@@ -27,6 +27,8 @@ spec:
             secretKeyRef:
               name: redis
               key: redis-password
+        - name: REDIS_URL
+          value: redis://redis:6379
         resources:
           limits:
             cpu: "1"

--- a/kubernetes/overlays/summit/kustomization.yaml
+++ b/kubernetes/overlays/summit/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
 - idle-deploy.yaml
 - ingest-deploy.yaml
 - redis-deploy.yaml
+- embargo-metrics-deploy.yaml
 
 secretGenerator:
 - name: s3

--- a/kubernetes/overlays/tts/embargo-metrics-deploy.yaml
+++ b/kubernetes/overlays/tts/embargo-metrics-deploy.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics
-        image: "ghcr.io/lsst-dm/embargo-butler-ingest:prod"
+        image: "image: ghcr.io/slaclab/rubin-embargo-metrics:latest"
         env:
         - name: REDIS_PASSWORD
           valueFrom:

--- a/kubernetes/overlays/tts/embargo-metrics-deploy.yaml
+++ b/kubernetes/overlays/tts/embargo-metrics-deploy.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: metrics
-        image: "image: ghcr.io/slaclab/rubin-embargo-metrics:latest"
+        image: "ghcr.io/slaclab/rubin-embargo-metrics:latest"
         env:
         - name: REDIS_PASSWORD
           valueFrom:

--- a/kubernetes/overlays/tts/embargo-metrics-deploy.yaml
+++ b/kubernetes/overlays/tts/embargo-metrics-deploy.yaml
@@ -27,6 +27,8 @@ spec:
             secretKeyRef:
               name: redis
               key: redis-password
+        - name: REDIS_URL
+          value: redis://redis:6379
         resources:
           limits:
             cpu: "1"

--- a/kubernetes/overlays/tts/embargo-metrics-deploy.yaml
+++ b/kubernetes/overlays/tts/embargo-metrics-deploy.yaml
@@ -2,21 +2,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: sts-embargo-metrics
+  name: tts-embargo-metrics
   labels:
     app: metrics
-    site: sts
+    site: tts
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: metrics
-      site: sts
+      site: tts
   template:
     metadata:
       labels:
         app: metrics
-        site: sts
+        site: tts
     spec:
       containers:
       - name: metrics

--- a/kubernetes/overlays/tts/kustomization.yaml
+++ b/kubernetes/overlays/tts/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
 - idle-deploy.yaml
 - ingest-deploy.yaml
 - redis-deploy.yaml
+- embargo-metrics-deploy.yaml
 
 secretGenerator:
 - name: s3


### PR DESCRIPTION
Add the deployment manifest for rubin-embargo metrics. This will work alongside with https://github.com/slaclab/rubin-embargo-metrics/pull/1  