### PR TITLE
add missing rubintv bucket policies

### DIFF
--- a/bucket-policies/rubin-rubintv-data-bts-policy.json
+++ b/bucket-policies/rubin-rubintv-data-bts-policy.json
@@ -1,0 +1,25 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "allow-read-rubintv-data-ro",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          "arn:aws:iam:::user/rubin-rubintv-data-ro"
+        ]
+      },
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+        "s3:ListBucket",
+        "s3:ListBucketVersions"
+      ],
+      "Resource": [
+        "arn:aws:s3:::rubin-rubintv-data-bts",
+        "arn:aws:s3:::rubin-rubintv-data-bts/*"
+      ]
+    }
+  ]
+}

--- a/bucket-policies/rubin-rubintv-data-summit-policy.json
+++ b/bucket-policies/rubin-rubintv-data-summit-policy.json
@@ -1,0 +1,25 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "allow-read-rubin-rubintv-data-summit",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          "arn:aws:iam:::user/rubin-rubintv-data-ro"
+        ]
+      },
+      "Action": [
+        "s3:GetBucketLocation",
+        "s3:GetObject",
+        "s3:GetObjectVersion",
+        "s3:ListBucket",
+        "s3:ListBucketVersions"
+      ],
+      "Resource": [
+        "arn:aws:s3:::rubin-rubintv-data-summit",
+        "arn:aws:s3:::rubin-rubintv-data-summit/*"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
these are the production sdfdirect bucket policies for the rubintv buckets.