### PR TITLE
DM-43558: Add LFA ingest.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Sample command:
 s3api --profile=wsummit put-bucket-notification-configuration --bucket=rubin-summit --notification-configuration=file:///path/to/my/config.json
 ```
 
+The file path must be visible to the apptainer container, which usually means that it must be under ``/sdf/home`` (and not symlinked from ``/sdf/data``).
+
 Note that changing a topic's attributes does not take effect until the bucket notification configurations are rewritten, even if they're updated with the exact same JSON.
 
 # Deployment Structure

--- a/kubernetes/overlays/lfa/Makefile
+++ b/kubernetes/overlays/lfa/Makefile
@@ -1,0 +1,30 @@
+SECRET_PATH ?= secret/rubin/usdf-embargo-dmz
+ENV = $(notdir ${CURDIR})
+
+get-secrets-from-vault:
+	mkdir -p etc/.secrets/
+	# internal redis password and Ceph notification secret
+	set -e; for i in redis notification; do vault kv get --field=$$i ${SECRET_PATH}/${ENV} > etc/.secrets/$$i ; done
+	# butler dbauth.yaml file with creds
+	set -e; for i in db-auth.yaml; do vault kv get --field=$$i secret/rubin/usdf-butler/client-config > etc/.secrets/$$i ; done
+	# butler Postgres creds
+	set -e; for i in password username; do vault kv get --field=$$i secret/rubin/usdf-butler/postgres > etc/.secrets/pg_$$i ; done
+	# s3 creds for data from the summit (s3df ceph bucket)
+	set -e; for i in access_key secret_key; do vault kv get --field=$$i ${SECRET_PATH}/${ENV}> etc/.secrets/$$i ; done
+	# optional rucio service account ssh key
+	for i in register_svc_rsa; do vault kv get --field=$$i ${SECRET_PATH}/${ENV} > etc/.secrets/$$i || echo ignoring missing $$i ; done
+
+clean-secrets:
+	rm -rf etc/.secrets/
+
+run-dump:
+	kubectl kustomize .
+
+dump: get-secrets-from-vault run-dump clean-secrets
+
+run-apply:
+	kubectl apply -k .
+
+apply: get-secrets-from-vault run-apply clean-secrets
+
+

--- a/kubernetes/overlays/lfa/enqueue-deploy.yaml
+++ b/kubernetes/overlays/lfa/enqueue-deploy.yaml
@@ -1,0 +1,56 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: embargo-butler-enqueue
+  labels:
+    app: enqueue
+  annotations:
+    metallb.universe.tf/address-pool: sdf-services
+spec:
+  type: LoadBalancer
+  ports:
+  - name: enqueue-webhook
+    port: 8080
+    protocol: TCP
+    targetPort: 8000
+  selector:
+    app: enqueue
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: embargo-butler-enqueue
+  labels:
+    app: enqueue
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: enqueue
+  template:
+    metadata:
+      labels:
+        app: enqueue
+    spec:
+      containers:
+      - name: enqueue
+        image: "ghcr.io/lsst-dm/embargo-butler-enqueue:prod"
+        env:
+        - name: REDIS_HOST
+          value: redis
+        - name: DATASET_REGEXP
+          value: "(FiberSpectrograph/.*\\.fits$|GenericCamera/.*_\\d{6}\\.fits$)"
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: redis
+              key: redis-password
+        - name: NOTIFICATION_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: notification
+              key: secret
+        resources:
+          limits:
+            cpu: "1"

--- a/kubernetes/overlays/lfa/idle-deploy.yaml
+++ b/kubernetes/overlays/lfa/idle-deploy.yaml
@@ -1,0 +1,31 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: embargo-butler-idle
+  labels:
+    app: idle
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: idle
+  template:
+    metadata:
+      labels:
+        app: idle
+    spec:
+      containers:
+      - name: idle
+        image: "ghcr.io/lsst-dm/embargo-butler-idle:prod"
+        env:
+        - name: REDIS_HOST
+          value: redis
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: redis
+              key: redis-password
+        resources:
+          limits:
+            cpu: "0.1"

--- a/kubernetes/overlays/lfa/ingest-deploy.yaml
+++ b/kubernetes/overlays/lfa/ingest-deploy.yaml
@@ -1,0 +1,109 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: embargo-butler-ingest-lfa
+  labels:
+    app: ingest-lfa
+    site: summit
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ingest-lfa
+      site: summit
+  template:
+    metadata:
+      labels:
+        app: ingest-lfa
+        site: summit
+    spec:
+      initContainers:
+      - name: "fix-secret-permissions"
+        image: "ghcr.io/lsst-dm/embargo-butler-ingest:prod"
+        command:
+        - "/bin/bash"
+        - "-c"
+        - |
+          cp -RL /secrets-raw/* /secrets
+          chmod 0400 /secrets/*
+        volumeMounts:
+        - mountPath: /secrets-raw
+          name: db-auth
+          readOnly: true
+        - mountPath: /secrets
+          name: secrets
+      containers:
+      - name: ingest
+        image: "ghcr.io/lsst-dm/embargo-butler-ingest:prod"
+        env:
+        - name: S3_ENDPOINT_URL
+          value: https://s3dfrgw.slac.stanford.edu
+        - name: REDIS_HOST
+          value: redis
+        - name: BUCKET
+          value: rubinobs-lfa-cp
+        - name: BUTLER_REPO
+          value: /sdf/group/rubin/repo/main
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: redis
+              key: redis-password
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              name: s3
+              key: s3_access
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: s3
+              key: s3_key
+        resources:
+          limits:
+            cpu: 500m
+            memory: "1Gi"
+        volumeMounts:
+        - mountPath: /home/lsst/.lsst
+          name: secrets
+        - mountPath: "/sdf/data/rubin"
+          name: "sdf-data-rubin"
+        - mountPath: "/sdf/group/rubin"
+          name: "sdf-group-rubin"
+      volumes:
+      - name: secrets
+        emptyDir: {}
+      - name: db-auth
+        secret:
+          secretName: db-auth
+      - name: "sdf-data-rubin"
+        persistentVolumeClaim:
+          claimName: "sdf-data-rubin"
+      - name: "sdf-group-rubin"
+        persistentVolumeClaim:
+          claimName: "sdf-group-rubin"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "sdf-data-rubin"
+spec:
+  storageClassName: "sdf-data-rubin"
+  accessModes:
+  - "ReadWriteMany"
+  resources:
+    requests:
+      storage: "1Gi"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "sdf-group-rubin"
+spec:
+  storageClassName: "sdf-group-rubin"
+  accessModes:
+  - "ReadWriteMany"
+  resources:
+    requests:
+      storage: "1Gi"

--- a/kubernetes/overlays/lfa/kustomization.yaml
+++ b/kubernetes/overlays/lfa/kustomization.yaml
@@ -1,0 +1,37 @@
+images:
+- name: ghcr.io/lsst-dm/embargo-butler-enqueue
+  newTag: "1.0"
+- name: ghcr.io/lsst-dm/embargo-butler-ingest
+  newTag: "1.0-w_2024_16"
+- name: ghcr.io/lsst-dm/embargo-butler-idle
+  newTag: "1.0"
+- name: docker.io/redis
+  newTag: "7.0.15"
+
+namespace: lfa
+
+resources:
+- ns.yaml
+- enqueue-deploy.yaml
+- idle-deploy.yaml
+- ingest-deploy.yaml
+- redis-deploy.yaml
+
+secretGenerator:
+- name: s3
+  files:
+  - s3_access=etc/.secrets/access_key
+  - s3_key=etc/.secrets/secret_key
+- name: redis
+  files:
+  - redis-password=etc/.secrets/redis
+- name: db-auth
+  files:
+  - db-auth.yaml=etc/.secrets/db-auth.yaml
+- name: db-env
+  files:
+  - pg_password=etc/.secrets/pg_password
+  - pg_user=etc/.secrets/pg_username
+- name: notification
+  files:
+  - secret=etc/.secrets/notification

--- a/kubernetes/overlays/lfa/ns.yaml
+++ b/kubernetes/overlays/lfa/ns.yaml
@@ -1,0 +1,4 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: lfa

--- a/kubernetes/overlays/lfa/redis-deploy.yaml
+++ b/kubernetes/overlays/lfa/redis-deploy.yaml
@@ -1,0 +1,91 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  type: ClusterIP
+  internalTrafficPolicy: Cluster
+  ports:
+  - name: redis
+    port: 6379
+    protocol: TCP
+    targetPort: 6379
+  selector:
+    app: redis
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redis
+  labels:
+    app: redis
+spec:
+  serviceName: redis
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      securityContext:
+        fsGroup: 999
+        runAsGroup: 999
+        runAsNonRoot: true
+        runAsUser: 999
+      containers:
+      - name: redis
+        image: "docker.io/redis:7.0.8"
+        command:
+        - redis-server
+        - '--appendonly'
+        - 'yes'
+        - '--requirepass'
+        - $(REDIS_PASSWORD)
+        env:
+        - name: MASTER
+          value: "true"
+        - name: REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: redis-password
+              name: redis
+        livenessProbe:
+          exec:
+            command:
+              - sh
+              - '-c'
+              - 'redis-cli -h $(hostname) -a $(REDIS_PASSWORD) incr health:counter'
+          failureThreshold: 3
+          initialDelaySeconds: 15
+          periodSeconds: 60
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1Gi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - all
+        ports:
+        - containerPort: 6379
+        volumeMounts:
+        - mountPath: /data
+          name: data
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes: [ "ReadWriteOnce"]
+      storageClassName: wekafs--sdf-k8s01
+      resources:
+        requests:
+          storage: 10Gi


### PR DESCRIPTION
This works for independent instruments ingested by RawIngestTask.  It's deployed as a separate namespace to keep it isolated from the critical science image ingest.