### PR TITLE
DM-53726

### DIFF
--- a/bucket-notifications/prod/rubin-summit-topic-config.json
+++ b/bucket-notifications/prod/rubin-summit-topic-config.json
@@ -1,15 +1,15 @@
 {
     "TopicConfigurations": [
         {
-            "Id": "rubin-ingest-embargo-new",
-            "TopicArn": "arn:aws:sns:sdfembargo::rubin-summit-new",
+            "Id": "rubin-ingest-embargo-new-2",
+            "TopicArn": "arn:aws:sns:rubin-zg::rubin-ingest-embargo-new-2",
             "Events": [
                 "s3:ObjectCreated:*"
             ]
         },
         {
-            "Id": "rubin-summit-notification-6",
-            "TopicArn": "arn:aws:sns:sdfembargo::rubin-summit-notification-6",
+            "Id": "rubin-summit-notification-7",
+            "TopicArn": "arn:aws:sns:sdfembargo::rubin-summit-notification-7",
             "Events": [
                 "s3:ObjectCreated:*"
             ]

--- a/bucket-notifications/prod/rubin-summit-topic.sh
+++ b/bucket-notifications/prod/rubin-summit-topic.sh
@@ -16,15 +16,15 @@ alias s3api="apptainer exec /sdf/sw/s3/aws-cli_latest.sif aws --endpoint-url htt
 s3api --profile=$profile put-bucket-notification-configuration --bucket=rubin-summit --notification-configuration=file://blank-topic-config.json
 
 # Delete the current topics and create a new ones
-sns delete-topic --topic-arn=arn:aws:sns:sdfembargo::rubin-summit-new
-sns delete-topic --topic-arn=arn:aws:sns:sdfembargo::rubin-summit-notification-6
-sns create-topic --name=rubin-ingest-embargo-new --attributes='{"push-endpoint": "http://172.24.5.156:8080/notify", "OpaqueData": "$summit_new_notification_key", "persistent": "false" }'
-sns create-topic --name=rubin-summit-notification-6 --attributes='{"push-endpoint": "kafka://172.24.10.54:9094", "OpaqueData": "", "persistent": "false" }'
+sns delete-topic --topic-arn=arn:aws:sns:rubin-zg::rubin-ingest-embargo-new-2
+sns delete-topic --topic-arn=arn:aws:sns:sdfembargo::rubin-summit-notification-7
+sns create-topic --name=rubin-ingest-embargo-new-2 --attributes='{"push-endpoint": "http://172.24.5.156:8080/notify", "OpaqueData": "'"$summit_new_notification_key"'", "persistent": "true" }'
+sns create-topic --name=rubin-summit-notification-7 --attributes='{"push-endpoint": "kafka://172.24.10.54:9094", "OpaqueData": "", "persistent": "true" }'
 
 # Set the Topic Configuration
 s3api put-bucket-notification-configuration --bucket=rubin-summit --notification-configuration=file://rubin-summit-topic-config.json
 
 # Validate the configuration
 s3api get-bucket-notification-configuration --bucket=rubin-summit
-sns get-topic-attributes --topic-arn arn:aws:sns:sdfembargo::rubin-summit-new
-sns get-topic-attributes --topic-arn arn:aws:sns:sdfembargo::rubin-summit-notification-6
+sns get-topic-attributes --topic-arn arn:aws:sns:rubin-zg::rubin-ingest-embargo-new-2
+sns get-topic-attributes --topic-arn arn:aws:sns:sdfembargo::rubin-summit-notification-7


### PR DESCRIPTION
Update notification config to new topics.  Persistent is set to `true` for both notification topics as it was already set to `true`.  Their is a difference in ARNs for the Butler Ingest webhook `arn:aws:sns:rubin-zg::` and Kafka topic `arn:aws:sns:sdfembargo::` which was used before.  This was an emergency change at night so did not notice the difference.  The ARN can be set to different values as long as it is referenced in the config and apply commands. Both topics work.