### PR TITLE
fix: update to lock ips and remove nodePorts

### DIFF
--- a/kubernetes/overlays/bts/enqueue-deploy.yaml
+++ b/kubernetes/overlays/bts/enqueue-deploy.yaml
@@ -6,9 +6,11 @@ metadata:
   labels:
     app: enqueue
   annotations:
-    metallb.universe.tf/address-pool: sdf-services
+    metallb.io/address-pool: sdf-services
+    metallb.io/loadBalancerIPs: 172.24.5.72
 spec:
   type: LoadBalancer
+  allocateLoadBalancerNodePorts: false
   ports:
   - name: enqueue-webhook
     port: 8080

--- a/kubernetes/overlays/lfa/enqueue-deploy.yaml
+++ b/kubernetes/overlays/lfa/enqueue-deploy.yaml
@@ -6,9 +6,11 @@ metadata:
   labels:
     app: enqueue
   annotations:
-    metallb.universe.tf/address-pool: sdf-services
+    metallb.io/address-pool: sdf-services
+    metallb.io/loadBalancerIPs: 172.24.5.72
 spec:
   type: LoadBalancer
+  allocateLoadBalancerNodePorts: false
   ports:
   - name: enqueue-webhook
     port: 8080

--- a/kubernetes/overlays/summit-new/enqueue-deploy.yaml
+++ b/kubernetes/overlays/summit-new/enqueue-deploy.yaml
@@ -6,9 +6,11 @@ metadata:
   labels:
     app: enqueue
   annotations:
-    metallb.universe.tf/address-pool: sdf-services
+    metallb.io/address-pool: sdf-services
+    metallb.io/loadBalancerIPs: 172.24.5.156
 spec:
   type: LoadBalancer
+  allocateLoadBalancerNodePorts: false
   ports:
   - name: enqueue-webhook
     port: 8080

--- a/kubernetes/overlays/summit-new/presence-deploy.yaml
+++ b/kubernetes/overlays/summit-new/presence-deploy.yaml
@@ -6,9 +6,11 @@ metadata:
   labels:
     app: presence
   annotations:
-    metallb.universe.tf/address-pool: sdf-services
+    metallb.io/address-pool: sdf-services
+    metallb.io/loadBalancerIPs: 172.24.5.156
 spec:
   type: LoadBalancer
+  allocateLoadBalancerNodePorts: false
   ports:
   - name: presence-http
     port: 8080


### PR DESCRIPTION
statically configure the existing IPs for the in-use Services
remove insecure nodePort configurations