### PR TITLE
Query redis from outside vcluster

### DIFF
--- a/kubernetes/overlays/summit-new/redis-deploy.yaml
+++ b/kubernetes/overlays/summit-new/redis-deploy.yaml
@@ -6,9 +6,10 @@ metadata:
   labels:
     app: redis
   annotations:
-    metallb.universe.tf/address-pool: sdf-rubin-ingest
+    metallb.io/address-pool: sdf-services
 spec:
   type: LoadBalancer
+  allocateLoadBalancerNodePorts: false
   ports:
   - name: redis
     port: 6379

--- a/kubernetes/overlays/summit-new/redis-deploy.yaml
+++ b/kubernetes/overlays/summit-new/redis-deploy.yaml
@@ -5,9 +5,10 @@ metadata:
   name: redis
   labels:
     app: redis
+  annotations:
+    metallb.universe.tf/address-pool: sdf-rubin-ingest
 spec:
-  type: ClusterIP
-  internalTrafficPolicy: Cluster
+  type: LoadBalancer
   ports:
   - name: redis
     port: 6379

--- a/kubernetes/overlays/summit-new/redis-deploy.yaml
+++ b/kubernetes/overlays/summit-new/redis-deploy.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: redis
   annotations:
-    metallb.io/address-pool: sdf-services
+    metallb.io/address-pool: sdf-rubin-ingest
 spec:
   type: LoadBalancer
   allocateLoadBalancerNodePorts: false


### PR DESCRIPTION
Access redis without having to port forward to reach it from outside the vcluster

This will cater to the ingest monitoring https://rubinobs.atlassian.net/browse/DM-55090