### PR TITLE
DM-55149: Add retry timeouts to rubin-summit notification topics

### DIFF
--- a/bucket-notifications/prod/rubin-summit-topic-config.json
+++ b/bucket-notifications/prod/rubin-summit-topic-config.json
@@ -1,8 +1,8 @@
 {
     "TopicConfigurations": [
         {
-            "Id": "rubin-ingest-embargo-new-3",
-            "TopicArn": "arn:aws:sns:rubin-zg::rubin-ingest-embargo-new-3",
+            "Id": "rubin-ingest-embargo-new-4",
+            "TopicArn": "arn:aws:sns:rubin-zg::rubin-ingest-embargo-new-4",
             "Events": [
                 "s3:ObjectCreated:*"
             ]

--- a/bucket-notifications/prod/rubin-summit-topic.sh
+++ b/bucket-notifications/prod/rubin-summit-topic.sh
@@ -1,7 +1,3 @@
-#!/bin/bash
-set -e
-shopt -s expand_aliases
-
 #Set S3 profile
 profile=embargo-rw
 
@@ -16,15 +12,22 @@ alias s3api="apptainer exec /sdf/sw/s3/aws-cli_latest.sif aws --endpoint-url htt
 s3api --profile=$profile put-bucket-notification-configuration --bucket=rubin-summit --notification-configuration=file://blank-topic-config.json
 
 # Delete the current topics and create a new ones
-sns delete-topic --topic-arn=arn:aws:sns:rubin-zg::rubin-ingest-embargo-new-3
+sns delete-topic --topic-arn=arn:aws:sns:rubin-zg::rubin-ingest-embargo-new-4
 sns delete-topic --topic-arn=arn:aws:sns:sdfembargo::rubin-summit-notification-8
-sns create-topic --name=rubin-ingest-embargo-new-3 --attributes='{"push-endpoint": "http://172.24.5.156:8080/notify", "OpaqueData": "'"$summit_new_notification_key"'", "persistent": "true" }'
-sns create-topic --name=rubin-summit-notification-8 --attributes='{"push-endpoint": "kafka://172.24.10.54:9094", "OpaqueData": "", "persistent": "true" }'
+
+# Sleep to allow topics to clear.
+echo "Starting sleep for 60 seconds to allow topics to clear"
+sleep 60
+echo "Sleep done"
+
+# Create new topics
+sns create-topic --name=rubin-ingest-embargo-new-4 --attributes='{"push-endpoint": "http://172.24.5.156:8080/notify", "OpaqueData": "'"$summit_new_notification_key"'", "persistent": "true", "max_retries": "3", "retry_sleep_duration": "10", "time_to_live": "60"}'
+sns create-topic --name=rubin-summit-notification-8 --attributes='{"push-endpoint": "kafka://172.24.10.54:9094", "OpaqueData": "", "persistent": "true", "max_retries": "3", "retry_sleep_duration": "10", "time_to_live": "60"}'
 
 # Set the Topic Configuration
 s3api put-bucket-notification-configuration --bucket=rubin-summit --notification-configuration=file://rubin-summit-topic-config.json
 
 # Validate the configuration
 s3api get-bucket-notification-configuration --bucket=rubin-summit
-sns get-topic-attributes --topic-arn arn:aws:sns:rubin-zg::rubin-ingest-embargo-new-3
+sns get-topic-attributes --topic-arn arn:aws:sns:rubin-zg::rubin-ingest-embargo-new-4
 sns get-topic-attributes --topic-arn arn:aws:sns:sdfembargo::rubin-summit-notification-8


### PR DESCRIPTION
Add retry settings to rubin-summit notification topics.  The defaults are `None` which is infinite retries which will cause performance issues on Ceph.  Changed name of webhook topic because the persistent notification metrics did not clear as they are supposed to and the work around is to create a new topic.

Sleep is added to the script to allow time for the topic configuration before.  Without this topic names haven't worked when trying to be re-used.